### PR TITLE
Update script.cocoascript

### DIFF
--- a/Blender 2.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Blender 2.sketchplugin/Contents/Sketch/script.cocoascript
@@ -178,7 +178,7 @@ else {
       }
       else {
         var fill = layer.style().fills().firstObject();
-        if( selected_border_color[id] !== undefined ) {
+        if (selected_border_color[id] instanceof MSColor) {
           var br = Math.round(getNum(selected_border_color[id].red(), selected_border_color[id+1].red(), i, parseInt(result)+2 ) * 255)
           var bg = Math.round(getNum(selected_border_color[id].green(), selected_border_color[id+1].green(), i, parseInt(result)+2 ) * 255)
           var bb = Math.round(getNum(selected_border_color[id].blue(), selected_border_color[id+1].blue(), i, parseInt(result)+2 ) * 255)

--- a/Blender 2.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Blender 2.sketchplugin/Contents/Sketch/script.cocoascript
@@ -11,7 +11,9 @@ var getColor = function(selectionType, layer) {
     if (layer instanceof MSTextLayer) {
       color = layer.textColor()
     } else {
-      color = layer.style().fills().firstObject().color()
+      if(layer.style().fills().length !== 0) {
+        color = layer.style().fills().firstObject().color()
+      }
     }
   } else {
     if (layer instanceof MSTextLayer) {

--- a/Blender 2.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Blender 2.sketchplugin/Contents/Sketch/script.cocoascript
@@ -17,7 +17,9 @@ var getColor = function(selectionType, layer) {
     if (layer instanceof MSTextLayer) {
       color = layer.style().borders().firstObject().color()
     } else {
-      color = layer.style().borders().firstObject().color()
+      if( layer.style().borders().firstObject() !== null ) {
+        color = layer.style().borders().firstObject().color()
+      }
     }
     
   }
@@ -176,13 +178,15 @@ else {
       }
       else {
         var fill = layer.style().fills().firstObject();
-        var br = Math.round(getNum(selected_border_color[id].red(), selected_border_color[id+1].red(), i, parseInt(result)+2 ) * 255)
-        var bg = Math.round(getNum(selected_border_color[id].green(), selected_border_color[id+1].green(), i, parseInt(result)+2 ) * 255)
-        var bb = Math.round(getNum(selected_border_color[id].blue(), selected_border_color[id+1].blue(), i, parseInt(result)+2 ) * 255)
-        var ba = Math.round(getNum(selected_border_color[id].alpha(), selected_border_color[id+1].alpha(), i, parseInt(result)+2 ) * 255)
-      
-        var border = layer.style().borders().firstObject();
-        border.color = MSColor.colorWithRed_green_blue_alpha( br / 255, bg / 255, bb / 255, ba / 255);
+        if( selected_border_color[id] !== undefined ) {
+          var br = Math.round(getNum(selected_border_color[id].red(), selected_border_color[id+1].red(), i, parseInt(result)+2 ) * 255)
+          var bg = Math.round(getNum(selected_border_color[id].green(), selected_border_color[id+1].green(), i, parseInt(result)+2 ) * 255)
+          var bb = Math.round(getNum(selected_border_color[id].blue(), selected_border_color[id+1].blue(), i, parseInt(result)+2 ) * 255)
+          var ba = Math.round(getNum(selected_border_color[id].alpha(), selected_border_color[id+1].alpha(), i, parseInt(result)+2 ) * 255)
+        
+          var border = layer.style().borders().firstObject();
+          border.color = MSColor.colorWithRed_green_blue_alpha( br / 255, bg / 255, bb / 255, ba / 255);
+        }
 
         var shape = selectedLayers[id];
         fill.color = MSColor.colorWithRed_green_blue_alpha( r / 255, g / 255, b / 255, a / 255);


### PR DESCRIPTION
A Sketch update must have broken the plugin. When an element does not have a border, it causes  the plugin to fail. I've added two checks:

1. In the `getColor` function, it checks if the for borders that are not text, then checks if there are any borders. If not, it just leaves "color" undefined.
2. In the part that creates the new element and sets the borders, it checks if the color is undefined and, if there is no color defined, skips the border settings.

Update: Added an additional check. When blending lines, getting the color will throw an error if the line does not have a fill. This adds a check to see if the array of fills is not zero and, if not zero, only then get the fill color.